### PR TITLE
Participant Count field and functionality

### DIFF
--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -175,6 +175,14 @@ class AdminHelp implements AdminHelpInterface {
     $this->fee();
   }
 
+  protected function participant_count() {
+    return '<p>' .
+      t('Total number of participants to be registered for this event upon submission of the form.') .
+      '</p><p>' .
+      t('Note that if a value is not given, the default Participant Count will be 1.') .
+      '</p>';
+  }
+
   protected function fee() {
     return '<p>' .
       t('Once added to the webform, this field can be configured in a number of ways by changing its settings.') .

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -860,6 +860,10 @@ class Fields implements FieldsInterface {
               'name' => t('Participant Fee'),
             ] + $moneyDefaults;
         }
+        $fields['participant_count'] = [
+          'name' => t('Participant Count'),
+          'type' => 'civicrm_number',
+        ];
       }
       if (isset($sets['membership'])) {
         $fields['membership_membership_type_id'] = [

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1196,7 +1196,18 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
                   if (empty($item['participant_id'])) {
                     $item['participant_id'] = $item['entity_id'] = $result['id'];
                   }
-                  $item['participant_count'] = wf_crm_aval($item, 'participant_count', 0) + 1;
+                  // Initialize the $participantCount as one.
+                  $participantCount = 1;
+                  // If there is a value set by the Participant Count field on the Webform, use that instead.
+                  if (isset($this->crmValues["civicrm_{$n}_participant_{$e}_participant_count"]) && $this->crmValues["civicrm_{$n}_participant_{$e}_participant_count"] !== '') {
+                    $participantCount = (int) $this->crmValues["civicrm_{$n}_participant_{$e}_participant_count"];
+                    // Get (or create if needed) a Price Set that has a value field that correctly counts the number of participants registered on submission.
+                    $participantPriceValueID = $this->utils->wf_crm_get_participant_price_set();
+                    // Set the price field value id to the result of the function that gets/creates the needed Price Set.
+                    $item['price_field_value_id'] = $participantPriceValueID;
+                  };
+                  // The participant count and qty should always be the same value.
+                  $item['participant_count'] = $item['qty'] = wf_crm_aval($item, 'participant_count', 0) + $participantCount;
                   break;
                 }
               }


### PR DESCRIPTION
Overview
----------------------------------------
This PR creates a new Participant Count field on the CiviCRM tab of Drupal Webform configuration so that users can enter the total amount of participants being registered. This code also introduces the functionality to ensure that, on submission, the Participant Count is handled correctly by creating and setting a hidden Price Field Value for the line item that corresponds to the event registation. 

Before
----------------------------------------
Previously, Webform submissions only counted as one participant registered, even if the form that was submitted intended to have multiple registrants.

After
----------------------------------------
With this PR, the Webform registers the correct amount of participants on submission
